### PR TITLE
Baseurl and social share icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 0.2.5 - June 19, 2015
+
+### Changed
+- `nemo_footer.html` to fix spaces in social icon names
+
+
 ## 0.2.4 - June 19, 2015
 
-### Added
+### Changed
 - `base.html` to output the baseurl variable which can be set in pages
+
 
 ## 0.2.3 - April 27, 2015
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 0.2.4 - June 19, 2015
+
+### Added
+- `base.html` to output the baseurl variable which can be set in pages
+
 ## 0.2.3 - April 27, 2015
 
 ### Added

--- a/_includes/nemo_footer.html
+++ b/_includes/nemo_footer.html
@@ -23,11 +23,11 @@
     </nav>
     <nav>
       <ul>
-        <li class="horizontal-list-item"><a href="http://facebook.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-  content/themes/cfpb_nemo/_/img/fb_footer_icon.png" alt="Visit us on Facebook"></a>&nbsp;&nbsp;</li>
-        <li class="horizontal-list-item"><a href="http://twitter.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-  content/themes/cfpb_nemo/_/img/twitter_footer_icon.png" alt="Visit us on Twitter"></a>&nbsp;&nbsp;</li>
-        <li class="horizontal-list-item"><a href="http://youtube.com/CFPB" class="noStyles"><img src="http://www.consumerfinance.gov/wp-  content/themes/cfpb_nemo/_/img/youtube_footer_icon.png" alt="Visit us on Youtube"></a>&nbsp;&nbsp;</li>
-        <li class="horizontal-list-item"><a href="http://flickr.com/cfpbphotos" class="noStyles"><img src="http://www.consumerfinance.gov/wp-  content/themes/cfpb_nemo/_/img/flickr_footer_icon.png" alt="Visit us on Flickr"></a>&nbsp;&nbsp;</li>
-        <li class="horizontal-list-item"><a href="/feed/" class="noStyles"><img src="http://www.consumerfinance.gov/wp-  content/themes/cfpb_nemo/_/img/rss_footer_icon.png" alt="Subscribe to updates with RSS"></a></li>
+        <li class="horizontal-list-item"><a href="http://facebook.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/fb_footer_icon.png" alt="Visit us on Facebook"></a>&nbsp;&nbsp;</li>
+        <li class="horizontal-list-item"><a href="http://twitter.com/cfpb" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/twitter_footer_icon.png" alt="Visit us on Twitter"></a>&nbsp;&nbsp;</li>
+        <li class="horizontal-list-item"><a href="http://youtube.com/CFPB" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/youtube_footer_icon.png" alt="Visit us on Youtube"></a>&nbsp;&nbsp;</li>
+        <li class="horizontal-list-item"><a href="http://flickr.com/cfpbphotos" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/flickr_footer_icon.png" alt="Visit us on Flickr"></a>&nbsp;&nbsp;</li>
+        <li class="horizontal-list-item"><a href="/feed/" class="noStyles"><img src="http://www.consumerfinance.gov/wp-content/themes/cfpb_nemo/_/img/rss_footer_icon.png" alt="Subscribe to updates with RSS"></a></li>
       </ul>
       <p>Visite nuestro sitio web en español</p>
       <p><a href="/es/" hreflang="es" class="link-button espanol-link">Español</a></p>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -73,8 +73,8 @@
 #}
 
 {% block css %}
-<!--[if lt IE 9]>      <link rel="stylesheet" href="/static/css/main.ie.min.css"> <![endif]-->
-<!--[if gt IE 8]><!--> <link rel="stylesheet" href="/static/css/main.min.css"> <!--<![endif]-->
+<!--[if lt IE 9]>      <link rel="stylesheet" href="{{ baseurl }}/static/css/main.ie.min.css"> <![endif]-->
+<!--[if gt IE 8]><!--> <link rel="stylesheet" href="{{ baseurl }}/static/css/main.min.css"> <!--<![endif]-->
 {% endblock %}
 
 {#
@@ -174,10 +174,9 @@
 #}
 
 {% block body_scripts %}
-    <script src="/static/js/main.min.js"></script>
+    <script src="{{ baseurl }}/static/js/main.min.js"></script>
 {% endblock %}
 
 </body>
 
 </html>
-

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cfgov-sheer-templates",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "homepage": "https://cfpb.github.io/",
   "authors": [
     "Consumer Financial Protection Bureau <tech@consumerfinance.gov>"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cfgov-sheer-templates",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://cfpb.github.io/",
   "authors": [
     "Consumer Financial Protection Bureau <tech@consumerfinance.gov>"


### PR DESCRIPTION
Added baseurl functionality so micro-sites based on these templates can be served out of a sub-directory while preserving the ability to have "relative to site root" links to static assets.

Fixed bug in image src for social share urls